### PR TITLE
Support GCP

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/util/testdriver.go
+++ b/util/testdriver.go
@@ -20,17 +20,21 @@ import (
 	"bytes"
 	"io/ioutil"
 	"k-bench/manager"
-	"k8s.io/client-go/dynamic"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
 
+	"k8s.io/client-go/dynamic"
+
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+
 	//"k8s.io/client-go/tools/clientcmd"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"k-bench/perf_util"
 	"os"
 	"os/exec"


### PR DESCRIPTION
## Proposed Changes
- Add GCP auth support to K-Bench

## Background
We compare the performance of [Constellation](https://github.com/edgelesssys/constellation) on Azure and GCP to the performance of AKS and GKE Kubernetes clusters.

For that purpose, support for GCP authentication is needed.

